### PR TITLE
CS-3774: removes copyright string and replaces with site feedback link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -77,7 +77,7 @@
 
         <footer class='clearfix'>
           <ul class='site-footer-nav-left'>
-            <li><div class='copyright'>NASA &copy; 2015 US National Aeronautics and Space Administration</div></li>
+            <li><a href='mailto:nasa-data@lists.arc.nasa.gov'>Site Feedback</a></li>
           </ul>
           <ul class='site-footer-nav-right'>
             <li><a href='http://www.nasa.gov/about/highlights/HP_Privacy.html' rel='nofollow'>Privacy Policy and Important Notices</a></li>


### PR DESCRIPTION
Addresses [ticket](https://socrata.atlassian.net/browse/CS-3774)

Removes the copyright link and replaces it with a feedback link.
