### PR TITLE
CS-3791: changes app token to link on API Foundry page

### DIFF
--- a/foundry/template.mst
+++ b/foundry/template.mst
@@ -60,7 +60,7 @@
 
 <p>All requests should include an <a href="http://dev.socrata.com/docs/app-tokens.html">app token</a> that identifies your application, and each application should have its own unique app token. A limited number of requests can be made without an app token, but they are subject to much lower throttling limits than request that do include one. With an app token, your application is guaranteed access to it's own pool of requests. If you don't have an app token yet, click the button to the right to sign up for one.</p>
 
-<div class="register"><a href="http://dev.socrata.com/register" target="_blank" class="btn btn-primary btn-lg pull-right"> <i class="fa fa-key fa-lg"></i> Sign up for app token!</a></div>
+<div class="register"><a href="/profile/app_tokens" target="_blank" class="btn btn-primary btn-lg pull-right"> <i class="fa fa-key fa-lg"></i> Sign up for app token!</a></div>
 
 <p>Once you have an app token, you can include it with your request either by using the <code>X-App-Token</code> HTTP header, or by passing it via the <code>$$app_token</code> parameter on your URL.</p>
 


### PR DESCRIPTION
- Updates link to point towards /profile/app_token. Keeps users on a NASA-branded page as opposed to directing them to a Socrata page.

*If a user is logged in it will take them directly to the app_token page on their profile. If a user is logged out it will direct them towards a log-in page and then to the app_token page. 
